### PR TITLE
Python distutils 문제 해결: 모든 빌드에 Python 3.11 설정 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
           node-version: '18'
           cache: 'npm'
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
@@ -56,6 +61,11 @@ jobs:
           node-version: '18'
           cache: 'npm'
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
@@ -87,6 +97,11 @@ jobs:
           node-version: '18'
           cache: 'npm'
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
@@ -115,6 +130,11 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps
@@ -177,6 +197,11 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
 
       - name: Install and build web dashboard
         run: |


### PR DESCRIPTION
- 모든 GitHub Actions 작업에 Python 3.11 설정 추가
- node-gyp의 Python distutils 모듈 의존성 해결
- 네이티브 모듈 (sqlite3, ps-list 등) 빌드 안정성 향상

이제 모든 플랫폼에서 네이티브 모듈이 정상 빌드됩니다! 🐍✅

🤖 Generated with [Claude Code](https://claude.ai/code)