### PR TITLE
GitHub Release 파일 업로드 500 에러 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,13 +165,26 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
 
+      - name: List downloaded files
+        run: |
+          echo "=== Downloaded artifacts ==="
+          find . -name "*.dmg" -o -name "*.zip" -o -name "*.exe" -o -name "*.msi" -o -name "*.AppImage" -o -name "*.deb" | sort
+          echo "=== File sizes ==="
+          find . -name "*.dmg" -o -name "*.zip" -o -name "*.exe" -o -name "*.msi" -o -name "*.AppImage" -o -name "*.deb" -exec ls -lh {} \;
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            macos-build/**/*
-            windows-build/**/*
-            linux-build/**/*
+            macos-build/*.dmg
+            macos-build/*.zip
+            macos-build/*.blockmap
+            windows-build/*.exe
+            windows-build/*.msi
+            windows-build/*.blockmap
+            linux-build/*.AppImage
+            linux-build/*.deb
+            linux-build/*.blockmap
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}


### PR DESCRIPTION
- 설치 파일만 선택적으로 업로드하도록 변경 (*.dmg, *.exe, *.AppImage 등)
- 내부 앱 파일들(locale.pak 등) 업로드 제외로 API 제한 방지
- 릴리스 전 파일 목록 확인 단계 추가
- 안정적인 GitHub Releases 업로드 보장

🤖 Generated with [Claude Code](https://claude.ai/code)