### PR TITLE
웹 UI URL 파라미터 Gist 자동 로드 기능 구현

### DIFF
--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -33,6 +33,79 @@ export class DataService {
     return null;
   }
 
+  // URL에서 Gist ID 추출
+  public static loadGistIdFromURL(): string | null {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('gist');
+  }
+
+  // URL의 Gist ID로부터 데이터 로드
+  public static async loadGistDataFromURL(): Promise<CompressedData | null> {
+    const gistId = this.loadGistIdFromURL();
+    if (!gistId) {
+      return null;
+    }
+
+    try {
+      console.log(`🔄 URL에서 Gist ID 감지: ${gistId}, 데이터 로드 시도...`);
+      
+      // 공개 Gist API 호출 (토큰 없이)
+      const response = await fetch(`https://api.github.com/gists/${gistId}`);
+      
+      if (!response.ok) {
+        throw new Error(`GitHub API Error: ${response.status}`);
+      }
+
+      const gist = await response.json();
+      const fileContent = gist.files['usage-data.json']?.content;
+      
+      if (!fileContent) {
+        throw new Error('usage-data.json 파일을 찾을 수 없습니다');
+      }
+
+      const structuredData = JSON.parse(fileContent);
+      
+      // 구조화된 데이터에서 오늘 날짜 추출
+      const today = new Date().toISOString().split('T')[0];
+      const todayData = structuredData[today];
+      
+      if (todayData && 'appUsage' in todayData) {
+        console.log(`✅ URL Gist에서 오늘(${today}) 데이터 로드 성공`);
+        return {
+          appUsage: todayData.appUsage || [],
+          dailyStats: todayData.dailyStats || {
+            total_apps: 0,
+            total_usage_seconds: 0,
+            date: today,
+          },
+          platformStats: todayData.platformStats || {
+            windows: { apps: [], stats: { total_apps: 0, total_usage_seconds: 0 } },
+            macos: { apps: [], stats: { total_apps: 0, total_usage_seconds: 0 } },
+            android: { apps: [], stats: { total_apps: 0, total_usage_seconds: 0 } },
+          }
+        };
+      } else {
+        console.log(`📋 URL Gist에 오늘(${today}) 데이터 없음`);
+        return {
+          appUsage: [],
+          dailyStats: {
+            total_apps: 0,
+            total_usage_seconds: 0,
+            date: today,
+          },
+          platformStats: {
+            windows: { apps: [], stats: { total_apps: 0, total_usage_seconds: 0 } },
+            macos: { apps: [], stats: { total_apps: 0, total_usage_seconds: 0 } },
+            android: { apps: [], stats: { total_apps: 0, total_usage_seconds: 0 } },
+          }
+        };
+      }
+    } catch (error) {
+      console.error('❌ URL Gist 데이터 로드 실패:', error);
+      return null;
+    }
+  }
+
   public static saveDataToURL(data: CompressedData): string | null {
     const compressed = this.compressData(data);
     if (compressed) {


### PR DESCRIPTION
주요 기능:
- URL ?gist=ID 파라미터로 특정 Gist 자동 로드
- 공개 Gist API 호출로 토큰 없이도 데이터 읽기 지원
- 구조화된 Gist에서 오늘 날짜 데이터만 추출하여 표시
- 기존 데이터 로드 우선순위 체계 개선

데이터 로드 순서:
1. URL 압축 데이터 (?data=)
2. URL Gist ID (?gist=)  ← 새로 추가
3. 환경변수 Gist ID
4. Electron API
5. 브라우저 기본 상태

이제 https://example.com/?gist=ID 형태로
특정 Gist 데이터를 웹에서 바로 볼 수 있습니다.

🤖 Generated with [Claude Code](https://claude.ai/code)