### PR TITLE
GitHub Actions 배포 경로 수정 및 웹 UI 기능 완성

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,11 @@ jobs:
       - name: Build React app
         run: npm run build
 
-      - name: Build web dashboard
-        run: |
-          cd usage-stats-web
-          npm install --legacy-peer-deps
-          npm run build
-
       - name: Upload web artifacts
         uses: actions/upload-artifact@v4
         with:
           name: web-build
-          path: usage-stats-web/build/
+          path: build/
 
   build-electron-macos:
     name: Build Electron (macOS)
@@ -144,9 +138,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install and build web dashboard
+      - name: Install and build React app
         run: |
-          cd usage-stats-web
           npm install --legacy-peer-deps
           npm run build
 
@@ -156,7 +149,7 @@ jobs:
       - name: Upload to Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: usage-stats-web/build
+          path: build
 
       - name: Deploy to Pages
         id: deployment


### PR DESCRIPTION
## Summary
GitHub Actions가 잘못된 디렉토리(usage-stats-web)를 배포하고 있던 문제 수정

## 문제점
- GitHub Actions가 `usage-stats-web/build/` 디렉토리를 배포
- 실제 수정된 웹 UI는 루트의 React 앱 (`build/`)
- 웹 UI URL 파라미터 Gist 자동 로드 기능이 배포되지 않음

## 해결사항
- [x] GitHub Pages 배포 경로를 루트 React 앱으로 변경
- [x] 중복된 web dashboard 빌드 단계 제거
- [x] 올바른 빌드 파일이 배포되도록 수정

## 예상 결과
이 PR 머지 후 GitHub Actions가 실행되면:
- 루트 React 앱이 빌드되어 GitHub Pages에 배포됨
- 웹 UI URL 파라미터 Gist 자동 로드 기능 정상 작동
- `https://tanktwo2.github.io/my-usage-track-ledger/?gist=7ecfb90402b739968cbbf9866615d32c` URL에서 데이터 표시

## Test plan
- [ ] PR 머지 후 GitHub Actions 실행 확인
- [ ] 웹 UI에서 `?gist=ID` URL 파라미터 동작 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)